### PR TITLE
fix re not found

### DIFF
--- a/src/plugins/image.py
+++ b/src/plugins/image.py
@@ -1,3 +1,4 @@
+import re
 from src.libraries.image import *
 from src.libraries.gosen_choyen import generate
 from nonebot import on_command, on_message, on_notice, on_regex


### PR DESCRIPTION
通过导入re模块，修复re模块无法识别的bug